### PR TITLE
index out of range error

### DIFF
--- a/dumpsnap.go
+++ b/dumpsnap.go
@@ -119,8 +119,13 @@ func main() {
 		// Decode
 		s := stats[int(msgType[0])]
 		if s.Name == "" {
-			s.Name = typeNames[int(msgType[0])]
-		}
+                        if int(msgType[0]) >= len(typeNames) {
+                                s.Name = string(msgType[0])
+                        } else {
+                                s.Name = typeNames[int(msgType[0])]
+                        }
+                }
+
 
 		var val interface{}
 


### PR DESCRIPTION
when running the dumpsnap tool, the tool crashes with an "index out of range" on a consul 1.8.2 snapshot.  This patch fixes this.