### PR TITLE
Add KV size breakdown

### DIFF
--- a/dumpsnap.go
+++ b/dumpsnap.go
@@ -23,13 +23,22 @@ type typeStats struct {
 	Sum, Count int
 }
 
-type statSlice []typeStats
+type kvStats struct {
+	Prefix     string
+	Sum, Count int
+}
 
-func (s statSlice) Len() int { return len(s) }
+type statSlice []typeStats
+type kstatSlice []kvStats
+
+func (s statSlice) Len() int  { return len(s) }
+func (s kstatSlice) Len() int { return len(s) }
 
 // Less sorts by size descending
-func (s statSlice) Less(i, j int) bool { return s[i].Sum > s[j].Sum }
-func (s statSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
+func (s statSlice) Less(i, j int) bool  { return s[i].Sum > s[j].Sum }
+func (s statSlice) Swap(i, j int)       { s[i], s[j] = s[j], s[i] }
+func (s kstatSlice) Less(i, j int) bool { return s[i].Sum > s[j].Sum }
+func (s kstatSlice) Swap(i, j int)      { s[i], s[j] = s[j], s[i] }
 
 var typeNames []string
 
@@ -96,6 +105,8 @@ func main() {
 
 	stats := make(map[int]typeStats)
 
+	kstats := make(map[string]kvStats)
+
 	cr := &countingReader{r: os.Stdin}
 
 	dec := codec.NewDecoder(cr, msgpackHandle)
@@ -144,6 +155,33 @@ func main() {
 		s.Count++
 		offset += size
 
+		if s.Name == "KVS" {
+			switch val := val.(type) {
+			case map[interface{}]interface{}:
+				// depth controls how many levels deep we keep separate
+				// kv stats for in the breakdown. this should probably
+				// be a CLI option at some point.
+				for k, v := range val {
+					depth := 2
+					if k == "Key" {
+						split := strings.Split(v.(string), "/")
+						if depth > len(split) {
+							depth = len(split)
+						}
+						keys := split[0:depth]
+						prefix := strings.Join(keys, "/")
+						kvs := kstats[prefix]
+						if kvs.Prefix == "" {
+							kvs.Prefix = prefix
+						}
+						kvs.Sum += size
+						kvs.Count++
+						kstats[prefix] = kvs
+					}
+				}
+			}
+		}
+		// fmt.Printf("%v\n", kstats)
 		stats[int(msgType[0])] = s
 	}
 
@@ -157,13 +195,41 @@ func main() {
 	// Sort the stat slice
 	sort.Sort(ss)
 
-	fmt.Printf("% 22s % 8s % 12s\n", "Record Type", "Count", "Total Size")
-	fmt.Printf("%s %s %s\n", strings.Repeat("-", 22), strings.Repeat("-", 8), strings.Repeat("-", 12))
+	fmt.Printf("%s\n", strings.Repeat("-", 52))
+	fmt.Println("RECORD SUMMARY")
+	fmt.Printf("%s\n", strings.Repeat("-", 52))
+	fmt.Printf("% 30s % 8s % 12s\n", "Record Type", "Count", "Total Size")
+	fmt.Printf("%s %s %s\n", strings.Repeat("-", 30), strings.Repeat("-", 8), strings.Repeat("-", 12))
 	for _, s := range ss {
-		fmt.Printf("% 22s % 8d % 12s\n", s.Name, s.Count, ByteSize(uint64(s.Sum)))
+		fmt.Printf("% 30s % 8d % 12s\n", s.Name, s.Count, ByteSize(uint64(s.Sum)))
 	}
-	fmt.Printf("%s %s %s\n", strings.Repeat("-", 22), strings.Repeat("-", 8), strings.Repeat("-", 12))
-	fmt.Printf("%s % 8s % 12s\n", strings.Repeat(" ", 22), "TOTAL:", ByteSize(uint64(offset)))
+	fmt.Printf("%s %s %s\n", strings.Repeat("-", 30), strings.Repeat("-", 8), strings.Repeat("-", 12))
+	fmt.Printf("%s % 8s % 12s\n", strings.Repeat(" ", 30), "TOTAL:", ByteSize(uint64(offset)))
+
+	if len(kstats) > 0 {
+		fmt.Println()
+
+		// Output key stats in size-order
+		ks := make(kstatSlice, 0, len(kstats))
+
+		for _, s := range kstats {
+			ks = append(ks, s)
+		}
+
+		// Sort the key stat slice
+		sort.Sort(ks)
+
+		fmt.Printf("%s\n", strings.Repeat("-", 44))
+		fmt.Println("KEY SIZE BREAKDOWN")
+		fmt.Printf("%s\n", strings.Repeat("-", 44))
+		fmt.Printf("% 22s % 8s % 12s\n", "Key Prefix", "Count", "Total Size")
+		fmt.Printf("%s %s %s\n", strings.Repeat("-", 22), strings.Repeat("-", 8), strings.Repeat("-", 12))
+		for _, s := range ks {
+			fmt.Printf("% 22s % 8d % 12s\n", s.Prefix, s.Count, ByteSize(uint64(s.Sum)))
+		}
+		fmt.Printf("%s %s %s\n", strings.Repeat("-", 22), strings.Repeat("-", 8), strings.Repeat("-", 12))
+		fmt.Printf("%s % 8s % 12s\n", strings.Repeat(" ", 22), "TOTAL:", ByteSize(uint64(offset)))
+	}
 }
 
 const (

--- a/dumpsnap.go
+++ b/dumpsnap.go
@@ -36,7 +36,7 @@ var typeNames []string
 func init() {
 	// These mirror the const values from
 	// https://github.com/hashicorp/consul/blob/master/agent/structs/structs.go#L37-L70
-	// (line numbers may change but I want to link to master so it shows most recent 
+	// (line numbers may change but I want to link to master so it shows most recent
 	// constants).
 	typeNames = []string{
 		"Register",
@@ -69,6 +69,8 @@ func init() {
 		"ACLAuthMethodSetRequestType",
 		"ACLAuthMethodDeleteRequestType",
 		"ChunkingStateType",
+		"FederationStateRequestType",
+		"SystemMetadataRequestType",
 	}
 }
 
@@ -119,7 +121,13 @@ func main() {
 		// Decode
 		s := stats[int(msgType[0])]
 		if s.Name == "" {
-			s.Name = typeNames[int(msgType[0])]
+			if int(msgType[0]) < len(typeNames) {
+				s.Name = typeNames[int(msgType[0])]
+			} else {
+				fmt.Printf("WARN: Unknown message type: %v\n", int(msgType[0]))
+				fmt.Println("WARN: Probably needs updating from https://github.com/hashicorp/consul/blob/master/agent/structs/structs.go#L37-L70")
+				fmt.Println()
+			}
 		}
 
 		var val interface{}

--- a/dumpsnap.go
+++ b/dumpsnap.go
@@ -181,7 +181,7 @@ func main() {
 				}
 			}
 		}
-		// fmt.Printf("%v\n", kstats)
+
 		stats[int(msgType[0])] = s
 	}
 


### PR DESCRIPTION
This updates the MessageType constants (two new ones had been added since this was made) and adds some protections around when that happens again.

The primary change though is adding a KV size breakdown to help determine where most of the KV space is being consumed in situations where there's a large amount of snapshot space being taken up by KVs.

Sample output:

```
----------------------------------------------------
RECORD SUMMARY
----------------------------------------------------
                   Record Type    Count   Total Size
------------------------------ -------- ------------
                           KVS     1038      234.4MB
                      Register        3        1.8KB
                         Index       11         295B
                     Autopilot        1         199B
         CoordinateBatchUpdate        1         166B
    FederationStateRequestType        1         139B
                     Tombstone        1         125B
             ChunkingStateType        1          12B
------------------------------ -------- ------------
                                 TOTAL:      234.4MB

--------------------------------------------
KEY SIZE BREAKDOWN
--------------------------------------------
            Key Prefix    Count   Total Size
---------------------- -------- ------------
               aws/ips     1000      234.3MB
             vault/sys        7        4.4KB
            vault/core       15        4.3KB
         vault/logical        4          2KB
                test/e        1          82B
                test/d        1          82B
                test/c        1          82B
                test/b        1          82B
                test/g        1          82B
                test/l        1          82B
                test/a        1          82B
                test/k        1          82B
                test/j        1          82B
                test/f        1          82B
                test/h        1          82B
                test/i        1          82B
---------------------- -------- ------------
                         TOTAL:      234.4MB
```

Ideally, the key depth for this would be a param, but for now it's hard-coded to `2`.